### PR TITLE
Fix/questionnaire exports

### DIFF
--- a/decidim-core/app/jobs/decidim/export_job.rb
+++ b/decidim-core/app/jobs/decidim/export_job.rb
@@ -11,10 +11,11 @@ module Decidim
 
       collection = export_manifest.collection.call(component, user)
       serializer = export_manifest.serializer
+      options = export_manifest.options
 
       export_data = Decidim::Exporters.find_exporter(format).new(collection, serializer).export
 
-      ExportMailer.export(user, name, export_data).deliver_now
+      ExportMailer.export(user, name, export_data, options).deliver_now
     end
   end
 end

--- a/decidim-core/app/mailers/decidim/export_mailer.rb
+++ b/decidim-core/app/mailers/decidim/export_mailer.rb
@@ -10,16 +10,21 @@ module Decidim
     # user        - The user to be notified.
     # export_name - The name of the export.
     # export_data - The data containing the result of the export.
+    # options     - Options regarding the export (zip: whether to send the attachment compressed in a .zip file).
     #
     # Returns nothing.
-    def export(user, export_name, export_data)
+    def export(user, export_name, export_data, options = { zip: true })
       @user = user
       @organization = user.organization
 
       filename = export_data.filename(export_name)
       filename_without_extension = export_data.filename(export_name, extension: false)
 
-      attachments["#{filename_without_extension}.zip"] = FileZipper.new(filename, export_data.read).zip
+      if options[:zip]
+        attachments["#{filename_without_extension}.zip"] = FileZipper.new(filename, export_data.read).zip
+      else
+        attachments[filename] = export_data.read
+      end
 
       with_user(user) do
         mail(to: "#{user.name} <#{user.email}>", subject: I18n.t("decidim.export_mailer.subject", name: filename))

--- a/decidim-core/app/mailers/decidim/export_mailer.rb
+++ b/decidim-core/app/mailers/decidim/export_mailer.rb
@@ -22,8 +22,10 @@ module Decidim
 
       if options[:zip]
         attachments["#{filename_without_extension}.zip"] = FileZipper.new(filename, export_data.read).zip
+        @zipped = true
       else
         attachments[filename] = export_data.read
+        @zipped = false
       end
 
       with_user(user) do

--- a/decidim-core/app/views/decidim/export_mailer/export.html.erb
+++ b/decidim-core/app/views/decidim/export_mailer/export.html.erb
@@ -1,1 +1,1 @@
-<%= t(".ready") %>
+<%= @zipped ? t(".ready_zipped") : t(".ready") %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -617,7 +617,8 @@ en:
         click_button: 'Click the next button to download your data. <br/> You will have the file available until %{date}. <br/> You will need <a href=''https://www.7-zip.org/''>7-Zip</a> to open it. Password: %{password}'
         download: Download
       export:
-        ready: Please find attached a zipped version of your export.
+        ready_zipped: Please find attached a zipped version of your export.
+        ready: Please find your export attached.
       subject: Your export "%{name}" is ready
     filters:
       linked_classes:

--- a/decidim-core/lib/decidim/exporters/export_manifest.rb
+++ b/decidim-core/lib/decidim/exporters/export_manifest.rb
@@ -91,6 +91,18 @@ module Decidim
         @formats ||= formats || DEFAULT_FORMATS
       end
 
+      DEFAULT_OPTIONS = { zip: true }.freeze
+
+      # Public: Defines options for the export.
+      #
+      # options - The hash containing the options.
+      #
+      # Returns the stored options if previously stored, or
+      # the default empty hash.
+      def options(options = DEFAULT_OPTIONS)
+        @options ||= options
+      end
+
       private
 
       # Private: Loads the given exporters when formats argument is provided.

--- a/decidim-core/spec/lib/exporters/export_manifest_spec.rb
+++ b/decidim-core/spec/lib/exporters/export_manifest_spec.rb
@@ -69,5 +69,23 @@ module Decidim
         end
       end
     end
+
+    describe "#options" do
+      context "when no options are specified" do
+        it "returns an empty hash" do
+          expect(subject.options).to eq(described_class::DEFAULT_OPTIONS)
+        end
+      end
+
+      context "when some options are specified" do
+        before do
+          subject.options option: "value"
+        end
+
+        it "returns the options hash" do
+          expect(subject.options).to eq(option: "value")
+        end
+      end
+    end
   end
 end

--- a/decidim-forms/app/assets/javascripts/decidim/forms/display_conditions.component.js.es6
+++ b/decidim-forms/app/assets/javascripts/decidim/forms/display_conditions.component.js.es6
@@ -170,11 +170,14 @@
 
     onFulfilled(id, fulfilled) {
       this.conditions[id].fulfilled = fulfilled;
+      const $fulfilled = this.wrapperField.find("input[name$=\\[display_conditions_fulfilled\\]]");
 
       if (this.mustShow()) {
+        $fulfilled.val("true");
         this.showQuestion();
       }
       else {
+        $fulfilled.val("false");
         this.hideQuestion();
       }
     }

--- a/decidim-forms/app/assets/stylesheets/decidim/forms/questionnaire-answers-pdf.scss
+++ b/decidim-forms/app/assets/stylesheets/decidim/forms/questionnaire-answers-pdf.scss
@@ -1,68 +1,112 @@
+$foreground: #202751;
+$background: #fafafa;
+$background-alt: darken($background, 5%);
+$white: white;
+
+$border-radius-top: 4px 4px 0 0;
+$border-radius-bottom: 0 0 4px 4px;
+
+$border: 1px solid $foreground;
+
+$small-padding: 10px;
+$padding: 25px;
+
 .questionnaire-answers{
+  font-family: 'Source Sans Pro', Helvetica, Roboto, Arial, sans-serif;
+
   .header{
-    h1{
+    .logo{
+      height: 1rem;
+      width: auto;
+    }
+
+    .title,
+    .subtitle,
+    .description{
       margin: 0;
-      padding: 25px;
-      background: rgb(59, 69, 87);
-      color: white;
-      border-radius: 4px 4px 0 0;
+      padding: $small-padding $padding;
+      background: $foreground;
+      color: $white;
+      border-radius: $border-radius-top;
+    }
+
+    .title{
+      padding: $padding;
+    }
+
+    .subtitle{
+      border-radius: 0;
+      padding-top: $padding;
+    }
+
+    .subtitle,
+    .description,
+    .answers-count{
+      background: $background-alt;
+      color: $foreground;
+    }
+
+    .answers-count{
+      margin: -1px 0;
+      padding: $padding;
     }
 
     .description{
-      margin: 0;
-      padding: 25px;
-      background: #f6f6f6;
-      color: #202751;
-      border-radius: 0 0 4px 4px;
+      border-radius: $border-radius-bottom;
     }
   }
 
   .answer{
-    margin-top: 25px;
-    background: #f6f6f6;
-    border-radius: 0 0 4px 4px;
+    margin-top: $padding;
+    background: $background;
+    border-radius: $border-radius-bottom;
 
     .title{
       page-break-inside: avoid;
-      border-radius: 4px 4px 0 0;
-      padding: 10px 25px;
-      background: rgb(59, 69, 87);
-      color: white;
+      border-radius: $border-radius-top;
+      padding: $small-padding $padding;
+      margin: 0;
+      background: $foreground;
+      color: $white;
     }
 
     .participant-info{
       margin-top: 0;
-      padding: 10px 25px;
+      padding: $small-padding $padding;
       width: 100%;
       text-align: center;
-      background: #eee;
-      color: #202751;
+      background: $background-alt;
+      color: $foreground;
+      border-bottom: $border;
       page-break-inside: avoid;
 
-      th:first-child{
-        text-align: left;
-      }
+      td,
+      th{
+        &:first-child{
+          text-align: left;
+        }
 
-      td:first-child{
-        text-align: left;
-      }
-
-      th:last-child{
-        text-align: right;
-      }
-
-      td:last-child{
-        text-align: right;
+        &:last-child{
+          text-align: right;
+        }
       }
     }
 
     .answers{
       padding: 25px;
 
+      .response{
+        ol,
+        ul,
+        dl{
+          color: red;
+        }
+      }
+
       .question{
         page-break-inside: avoid;
         font-size: inherit;
-        color: #202751;
+        color: $foreground;
       }
     }
   }

--- a/decidim-forms/app/assets/stylesheets/decidim/forms/questionnaire-answers-pdf.scss
+++ b/decidim-forms/app/assets/stylesheets/decidim/forms/questionnaire-answers-pdf.scss
@@ -96,10 +96,11 @@ $padding: 25px;
       padding: 25px;
 
       .response{
-        ol,
-        ul,
-        dl{
-          color: red;
+        dt{
+          font-weight: bold;
+        }
+        dd, dt{
+          margin: $small-padding 0;
         }
       }
 

--- a/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
+++ b/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
@@ -30,7 +30,7 @@ module Decidim
 
       def answer_questionnaire
         Answer.transaction do
-          form.responses_by_step.flatten.select(&:display_conditions_fulfilled?).each do |form_answer|
+          form.responses_by_step.flatten.select(&:display_conditions_fulfilled?).reject(&:separator?).each do |form_answer|
             answer = Answer.new(
               user: @current_user,
               questionnaire: @questionnaire,

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -8,7 +8,7 @@ module Decidim
 
       attribute :question_id, String
       attribute :body, String
-      attribute :display_conditions_fulfilled, Boolean
+      attribute :display_conditions_fulfilled, Boolean, default: true
       attribute :choices, Array[AnswerChoiceForm]
       attribute :matrix_choices, Array[AnswerChoiceForm]
 
@@ -19,7 +19,7 @@ module Decidim
       validate :all_choices, if: -> { question.question_type == "sorting" }
       validate :min_choices, if: -> { question.matrix? && question.mandatory? }
 
-      delegate :mandatory_body?, :mandatory_choices?, :matrix?, to: :question
+      delegate :mandatory_body?, :mandatory_choices?, :matrix?, :separator?, to: :question
 
       attr_writer :question
 

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -56,6 +56,8 @@ module Decidim
         end
       end
 
+      delegate :separator?, to: :question
+
       private
 
       def mandatory_body?

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -8,6 +8,7 @@ module Decidim
 
       attribute :question_id, String
       attribute :body, String
+      attribute :display_conditions_fulfilled, Boolean
       attribute :choices, Array[AnswerChoiceForm]
       attribute :matrix_choices, Array[AnswerChoiceForm]
 
@@ -49,23 +50,14 @@ module Decidim
         choices.select(&:body)
       end
 
-      def display_conditions_fulfilled?
-        question.display_conditions.all? do |condition|
-          answer = question.questionnaire.answers.find_by(question: condition.condition_question)
-          condition.fulfilled?(answer)
-        end
-      end
-
-      delegate :separator?, to: :question
-
       private
 
       def mandatory_body?
-        question.mandatory_body? if display_conditions_fulfilled?
+        question.mandatory_body? if display_conditions_fulfilled
       end
 
       def mandatory_choices?
-        question.mandatory_choices? if display_conditions_fulfilled?
+        question.mandatory_choices? if display_conditions_fulfilled
       end
 
       def grouped_choices

--- a/decidim-forms/app/jobs/decidim/forms/export_questionnaire_answers_job.rb
+++ b/decidim-forms/app/jobs/decidim/forms/export_questionnaire_answers_job.rb
@@ -12,7 +12,7 @@ module Decidim
         serializer = Decidim::Forms::UserAnswersSerializer
         export_data = Decidim::Exporters::FormPDF.new(answers, serializer).export
 
-        ExportMailer.export(user, title, export_data).deliver_now
+        ExportMailer.export(user, title, export_data, zip: false).deliver_now
       end
     end
   end

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -12,29 +12,53 @@ module Decidim
         attribute :answer, Decidim::Forms::Answer
 
         def question
-          translated_attribute(answer.question.body)
+          translated_attribute(answer.question.body, organization)
         end
 
         def body
-          return answer.body if answer.body.present?
+          return simple_format answer.body if answer.body.present?
           return "-" if answer.choices.empty?
 
-          choices = answer.choices.map do |choice|
-            choice.try(:custom_body) || choice.try(:body)
-          end
+          return answer.choices.first.body if answer.question.question_type == "single_option"
 
-          return choices.first if answer.question.question_type == "single_option"
+          present_choices
+        end
 
-          content_tag(:ul) do
-            safe_join(choices.map { |c| choice(c) })
-          end
+        def text?
+          %w(short_answer long_answer).include? answer.question.question_type.to_s
         end
 
         private
 
-        def choice(choice_body)
-          content_tag :li do
-            choice_body
+        def organization
+          answer.questionnaire.questionnaire_for&.organization
+        end
+
+        def choice_body(choice)
+          choice.try(:custom_body) || choice.try(:body)
+        end
+
+        def present_choices
+          if answer.question.matrix?
+            content_tag :dl do
+              safe_join(
+                answer.choices.map do |c|
+                  matrix_row = answer.question.matrix_rows.find_by(id: c.matrix_row.id)
+                  safe_join([
+                              content_tag(:dt, translated_attribute(matrix_row.body)),
+                              content_tag(:dd, choice_body(c))
+                            ])
+                end
+              )
+            end
+          else
+            content_tag(answer.question.question_type == "sorting" ? :ol : :ul) do
+              safe_join(
+                answer.choices.map do |c|
+                  content_tag(:li, choice_body(c))
+                end
+              )
+            end
           end
         end
       end

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_participant_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_participant_presenter.rb
@@ -52,7 +52,7 @@ module Decidim
         private
 
         def sibilings
-          Answer.where(session_token: participant.session_token).joins(:question).order("decidim_forms_questions.position ASC")
+          Answer.where(questionnaire: questionnaire, session_token: participant.session_token).joins(:question).order("decidim_forms_questions.position ASC")
         end
       end
     end

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_participant_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_participant_presenter.rb
@@ -41,12 +41,14 @@ module Decidim
         end
 
         def completion
+          questions_count = questionnaire.questions.where.not(question_type: Question::SEPARATOR_TYPE).count
+
           with_body = sibilings.where("decidim_forms_questions.question_type in (?)", %w(short_answer long_answer))
                                .where.not(body: "").count
           with_choices = sibilings.where.not("decidim_forms_questions.question_type in (?)", %w(short_answer long_answer))
                                   .where("decidim_forms_answers.id IN (SELECT decidim_answer_id FROM decidim_forms_answer_choices)").count
 
-          (with_body + with_choices).to_f / questionnaire.questions.count * 100
+          (with_body + with_choices).to_f / questions_count * 100
         end
 
         private

--- a/decidim-forms/app/queries/decidim/forms/questionnaire_user_answers.rb
+++ b/decidim-forms/app/queries/decidim/forms/questionnaire_user_answers.rb
@@ -21,7 +21,7 @@ module Decidim
       # Finds and group answers by user for each questionnaire's question.
       def query
         answers = Answer.where(questionnaire: @questionnaire)
-        answers.sort_by { |answer| answer.question.position }.group_by { |a| a.user || a.session_token }.values
+        answers.sort_by { |answer| answer.question.position.to_i }.group_by { |a| a.user || a.session_token }.values
       end
     end
   end

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
@@ -25,7 +25,7 @@
   <div class="answers">
     <% participant.answers.each do |answer| %>
       <h3 class="question"><%= answer.question %></h3>
-      <p><%= answer.body %></p>
+      <div class="response"><%= answer.body %></div>
     <% end %>
   </div>
 </div>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/pdf.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/pdf.html.erb
@@ -1,13 +1,33 @@
 <div class="questionnaire-answers">
   <div class="header">
-    <h1><%= translated_attribute(questionnaire.title) %></h1>
-    <div class="description">
-      <%== translated_attribute(questionnaire.description).html_safe %>
-    </div>
+    <% organization = questionnaire.questionnaire_for.organization %>
+
+    <h1 class="title">
+      <% if organization.logo.present? %>
+        <div class="logo">
+          <%= wicked_pdf_image_tag organization.logo.url %>
+        </div>
+      <% end %>
+      <%= organization.name %>
+    </h1>
+    <h2 class="subtitle">
+      <%= translated_attribute(questionnaire.title) %>
+    </h2>
+
     <% if collection.count > 1 %>
-      <h2><%= t("title", scope: "decidim.forms.admin.questionnaires.answers.index", total: collection.count) %></h2>
+      <h3 class="answers-count"><%= t("title", scope: "decidim.forms.admin.questionnaires.answers.index", total: collection.count) %></h3>
     <% end %>
+
+    <div class="description">
+      <%= translated_attribute(questionnaire.description).html_safe %>
+    </div>
   </div>
 
-  <%= render partial: "decidim/forms/admin/questionnaires/answers/export/answer", collection: collection, locals: { questionnaire: questionnaire }, as: :participant %>
+  <div class="content">
+    <%= render partial: "decidim/forms/admin/questionnaires/answers/export/answer", collection: collection, locals: { questionnaire: questionnaire }, as: :participant %>
+  </div>
+
+  <footer class="page-footer">
+    <%= t("footer", scope: "decidim.forms.admin.questionnaires.answers.index") %>
+  </footer>
 </div>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/index.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/index.html.erb
@@ -15,7 +15,6 @@
             <th>#</th>
             <th><%= first_table_th(@participants.first) %></th>
             <th><%= t("user_status",   scope: "decidim.forms.user_answers_serializer") %></th>
-            <th><%= t("ip_hash",       scope: "decidim.forms.user_answers_serializer") %></th>
             <th><%= t("completion",    scope: "decidim.forms.user_answers_serializer") %></th>
             <th><%= t("created_at",    scope: "decidim.forms.user_answers_serializer") %></th>
             <th></th>
@@ -32,7 +31,6 @@
                   <%= first_table_td(participant) %></td>
                 <% end %>
               <td><%= participant.status %></td>
-              <td><%= participant.ip_hash %></td>
               <td><%= display_percentage(participant.completion) %></td>
               <td><%= l participant.answered_at, format: :short %></td>
               <td class="table-list__actions">

--- a/decidim-forms/app/views/decidim/forms/questionnaires/_answer.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/_answer.html.erb
@@ -15,6 +15,7 @@
   <%= render partial: "decidim/forms/questionnaires/answers/#{answer.question.question_type}", locals: { answer: answer, answer_form: answer_form, answer_idx: answer_idx, field_id: field_id, disabled: disabled } %>
 
   <%= answer_form.hidden_field :question_id %>
+  <%= answer_form.hidden_field :display_conditions_fulfilled %>
 
   <small class="form-error max-choices-alert"><%= t(".max_choices_alert") %></small>
 

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
             export_response:
               title: survey_user_answers_%{token}
             index:
+              footer: Made with Decidim
               title: "%{total} total responses"
             show:
               title: 'Answer #%{number}'

--- a/decidim-forms/spec/forms/decidim/forms/answer_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/answer_form_spec.rb
@@ -6,7 +6,9 @@ module Decidim
   module Forms
     describe AnswerForm do
       subject do
-        described_class.from_model(answer)
+        form = described_class.from_model(answer)
+        form.display_conditions_fulfilled = display_conditions_fulfilled
+        form
       end
 
       let(:mandatory) { false }
@@ -16,6 +18,8 @@ module Decidim
       let!(:questionable) { create(:dummy_resource) }
       let!(:questionnaire) { create(:questionnaire, questionnaire_for: questionable) }
       let!(:user) { create(:user, organization: questionable.organization) }
+
+      let(:display_conditions_fulfilled) { true }
 
       let!(:question) do
         create(
@@ -71,13 +75,14 @@ module Decidim
             subject.body = nil
           end
 
-          it "is valid if display_conditions are not fulfilled" do
-            expect(subject).to be_valid
+          context "if display_conditions are not fulfilled" do
+            let(:display_conditions_fulfilled) { false }
+            it { is_expected.to be_valid }
           end
-
-          it "is not valid if display_conditions are fulfilled" do
-            create(:answer, question: condition_question, questionnaire: questionnaire, body: "The answer")
-            expect(subject).not_to be_valid
+          
+          context "if display_conditions are fulfilled" do
+            let(:display_conditions_fulfilled) { true }
+            it { is_expected.not_to be_valid }
           end
         end
       end

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
@@ -15,8 +15,8 @@ module Decidim
           answer.body = "abc"
         end
 
-        it "Returns the answer body" do
-          expect(subject.body).to eq(answer.body)
+        it "Returns the formatted answer body" do
+          expect(subject.body).to eq("<p>#{answer.body}</p>")
         end
       end
 
@@ -49,6 +49,35 @@ module Decidim
 
           it "Returns the choice's body as a <li> element inside a <ul>" do
             expect(subject.body).to eq("<ul><li>#{answer_choice.body}</li></ul>")
+          end
+        end
+
+        context "when it is a matrix_single question" do
+          let!(:question) { create :questionnaire_question, questionnaire: questionnaire, question_type: "matrix_single" }
+          let!(:matrix_row) { create :question_matrix_row, question: question }
+          let!(:answer) { create(:answer, questionnaire: questionnaire, question: question, body: nil) }
+          let!(:answer_option) { create :answer_option, question: question }
+          let!(:answer_choice) { create :answer_choice, answer: answer, answer_option: answer_option, matrix_row: matrix_row, body: translated(answer_option.body, locale: I18n.locale) }
+
+          it "Returns the choice's body as a <dd> element preceded by a <dt> with the matrix row body, both inside a <dl>" do
+            expect(subject.body).to eq("<dl><dt>#{translated matrix_row.body}</dt><dd>#{answer_choice.body}</dd></dl>")
+          end
+        end
+
+        context "when it is a matrix_multiple question" do
+          let!(:question) { create :questionnaire_question, questionnaire: questionnaire, question_type: "matrix_multiple" }
+          let!(:matrix_rows) { create_list :question_matrix_row, 2, question: question }
+          let!(:answer) { create(:answer, questionnaire: questionnaire, question: question, body: nil) }
+          let!(:answer_options) { create_list :answer_option, 2, question: question }
+          let!(:answer_choice_1) { create :answer_choice, answer: answer, answer_option: answer_options.first, matrix_row: matrix_rows.second }
+          let!(:answer_choice_2) { create :answer_choice, answer: answer, answer_option: answer_options.first, matrix_row: matrix_rows.first }
+          let!(:answer_choice_3) { create :answer_choice, answer: answer, answer_option: answer_options.second, matrix_row: matrix_rows.first }
+
+          it "Returns the choice's body as <dd> elements preceded by a <dt> with the matrix row body, all inside a <dl>" do
+            expect(subject.body).to match "<dl>.*</dl>"
+            expect(subject.body).to include "<dt>#{translated matrix_rows.second.body}</dt><dd>#{answer_choice_1.body}</dd>"
+            expect(subject.body).to include "<dt>#{translated matrix_rows.first.body}</dt><dd>#{answer_choice_2.body}</dd>"
+            expect(subject.body).to include "<dt>#{translated matrix_rows.first.body}</dt><dd>#{answer_choice_3.body}</dd>"
           end
         end
       end

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -74,6 +74,8 @@ Decidim.register_component(:surveys) do |component|
     exports.formats %w(CSV JSON Excel FormPDF)
 
     exports.serializer Decidim::Forms::UserAnswersSerializer
+
+    exports.options zip: false
   end
 
   component.seeds do |participatory_space|

--- a/decidim-surveys/spec/shared/export_survey_user_answers_examples.rb
+++ b/decidim-surveys/spec/shared/export_survey_user_answers_examples.rb
@@ -21,7 +21,7 @@ shared_examples "export survey user answers" do
 
     expect(last_email.subject).to include("survey_user_answers", "csv")
     expect(last_email.attachments.length).to be_positive
-    expect(last_email.attachments.first.filename).to match(/^survey_user_answers.*\.zip$/)
+    expect(last_email.attachments.first.filename).to match(/^survey_user_answers.*\.csv$/)
   end
 
   it "exports a JSON" do
@@ -36,7 +36,22 @@ shared_examples "export survey user answers" do
 
     expect(last_email.subject).to include("survey_user_answers", "json")
     expect(last_email.attachments.length).to be_positive
-    expect(last_email.attachments.first.filename).to match(/^survey_user_answers.*\.zip$/)
+    expect(last_email.attachments.first.filename).to match(/^survey_user_answers.*\.json$/)
+  end
+  
+  it "exports an Excel" do
+    visit_component_admin
+
+    find(".exports.dropdown").click
+    perform_enqueued_jobs { click_link "Excel" }
+
+    within ".callout.success" do
+      expect(page).to have_content("in progress")
+    end
+
+    expect(last_email.subject).to include("survey_user_answers", "xls")
+    expect(last_email.attachments.length).to be_positive
+    expect(last_email.attachments.first.filename).to match(/^survey_user_answers.*\.xls$/)
   end
 
   it "exports a PDF" do
@@ -51,6 +66,6 @@ shared_examples "export survey user answers" do
 
     expect(last_email.subject).to include("survey_user_answers", "pdf")
     expect(last_email.attachments.length).to be_positive
-    expect(last_email.attachments.first.filename).to match(/^survey_user_answers.*\.zip$/)
+    expect(last_email.attachments.first.filename).to match(/^survey_user_answers.*\.pdf$/)
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes some bugs related to exporting questionnaires and adds some other improvements:

- Exports
  - Adds `options` hash for `export_manifest` to decide whether file should be zipped
  - Makes surveys exports not be zipped by default to improve UX
- Form PDF
  - Render newlines for `short_answer` and `long_answer` answers
  - Render matrix answers correctly
  - Remove `ip_hash` to improve readability of participant information
- Bugfixes
  - Remove bug happening when exporting answers to questions with `position: nil`

#### :pushpin: Related issues
- Related to https://github.com/Platoniq/decidim/issues/27

#### :clipboard: Subtasks
- [ ] Add tests
- [ ] Add question_count to questionnaire to skip separators in count >> fix completion percentage calculation for questionnaires
- [ ] Check why organization logo is not being rendered in pdf
- [ ] Design for PDF footer 'made with Decidim'
- [ ] Change export email message so it doesn't say "zipped" 
