### PR TITLE
Add videoconference.js to meetings js manifest

### DIFF
--- a/decidim-meetings/app/assets/config/decidim_meetings_manifest.js
+++ b/decidim-meetings/app/assets/config/decidim_meetings_manifest.js
@@ -6,4 +6,5 @@
 //= link decidim/meetings/meetings_form.js
 //= link decidim/meetings/admin/agendas.js
 //= link decidim/meetings/admin/destroy_meeting_alert.js
+//= link decidim/meetings/videoconference.js
 //= link_tree ../images/decidim


### PR DESCRIPTION
Adds `videoconference.js.es6` to `decidim-meetings/app/assets/config/decidim_meetings_manifest.js`